### PR TITLE
Add Hill48 yield criterion

### DIFF
--- a/example.py
+++ b/example.py
@@ -16,6 +16,12 @@ steel.set_yield_function('vonMises', sigma_y0 = 240e6)
 # for Linear hardening only H is needed: sigma_y = sigma_y0 + H*epbar
 # for Swift hardening, define e_0 and n: sigma_y = K*(e_0 + epbar)^n, with K = sigma_y0/(e_0^n)
 steel.set_hardening_law('Swift', n=0.15, e_0=0.0005)
+# Example using Hill48 yield function
+aluminum = material.isotropic(E=210e9, mu=0.3)
+aluminum.set_yield_function(
+    'Hill48', sigma_y0=240e6, F=0.5, G=1.0, H=0.5, N=1.5
+)
+aluminum.set_hardening_law('Swift', n=0.15, e_0=0.0005)
 # Define a stress tensor (must be numpy array)
 import numpy as np
 stress = 1.0e6 * np.array([[140, 120, 0],
@@ -23,6 +29,7 @@ stress = 1.0e6 * np.array([[140, 120, 0],
 	                       [0  ,0   ,20]])
 # Get equivalent stress for this stress state
 print(steel.get_equiv_stress(stress))
+print(aluminum.get_equiv_stress(stress))
 # Set this stress state as the initial material state
 steel.set_initial_stress(1e6*np.array([[140,120,0],[120,40,0],[0,0,20]]))
 # and set the initial accumulated plastic strain as zero

--- a/yield_function.py
+++ b/yield_function.py
@@ -49,6 +49,32 @@ class vonMises(yield_functions):
         f = sigma_eq - sigma_y
         return f
 
+
+class Hill48(yield_functions):
+    """Hill48 anisotropic yield criterion for plane stress."""
+    def __init__(self, kwargs):
+        self.sigma_y0 = kwargs['sigma_y0']
+        self.F = kwargs['F']
+        self.G = kwargs['G']
+        self.H = kwargs['H']
+        self.N = kwargs['N']
+
+    def get_equivalent_stress(self, Cauchy):
+        sigma_xx = Cauchy[0, 0]
+        sigma_yy = Cauchy[1, 1]
+        tau_xy = Cauchy[0, 1]
+        phi = (
+            self.F * sigma_yy ** 2
+            + self.G * sigma_xx ** 2
+            + self.H * (sigma_xx - sigma_yy) ** 2
+            + 2.0 * self.N * tau_xy ** 2
+        )
+        return np.sqrt(phi)
+
+    def get_yield_function_value(self, Cauchy, sigma_y):
+        sigma_eq = self.get_equivalent_stress(Cauchy)
+        return sigma_eq - sigma_y
+
     def plot_function(self, the_axes, sigma_y, color = None):
         """Plot von Mises yield function in the deviatoric plane.
            It is a circumference of radius sqrt(2/3)*sigma_y."""
@@ -142,4 +168,7 @@ class vonMises(yield_functions):
         return Cauchy, epbar, Cauchy_trial
 
 # Define the dictionary that relates yield function names to their sub-class
-link_name = {'vonMises': vonMises}
+link_name = {
+    'vonMises': vonMises,
+    'Hill48': Hill48,
+}


### PR DESCRIPTION
## Summary
- implement Hill48 plane-stress yield function
- expose the class through `link_name`
- show how to use Hill48 in `example.py`

## Testing
- `python -m py_compile yield_function.py material.py hardening_law.py utils.py example.py`

------
https://chatgpt.com/codex/tasks/task_e_68487c085a1c8329bb45b480f95e55ce